### PR TITLE
remove unnecessary src value for profile definition in manifest

### DIFF
--- a/docs/docs/packaging/manifest.md
+++ b/docs/docs/packaging/manifest.md
@@ -77,9 +77,6 @@ The `image` has more priority than the `git` option. If both are provided, the `
 # Name of the profile
 name: <string>
 
-# Relative path to the profile inside the package (relative to the manifest.yml file)
-src: <string>
-
 # Import settings from other profiles
 from_profile:
   # Import docker-compose.yml from <profile>


### PR DESCRIPTION
The value `src` here is redundant imo if you follow the Tap structure. profile folder will be the same name as the profile `name` value