### PR TITLE
Update `enum` type

### DIFF
--- a/docs/docs/packaging/profiles.md
+++ b/docs/docs/packaging/profiles.md
@@ -98,7 +98,7 @@ str: "Hello, World!"
 path_dir: ./path/to/a/dir
 path_file: ./path/to/a/file
 uri: https://eigenlayer.com
-enum: [value1, value2, value3]
+select: option1
 port: 8080
 id: "eigenlayer"
 ```
@@ -140,6 +140,9 @@ min_value: <int|float>
 
 # Max value that could be, included. Will be ignored if it is used for a type different from <int> or <float>
 max_value: <int|float>
+
+# List of possible options to select. Will be ignored if it is used for a type different from <select>
+options: [ - <string> ]
 ```
 
 ### `<monitoring>`

--- a/docs/docs/packaging/reference.md
+++ b/docs/docs/packaging/reference.md
@@ -110,8 +110,10 @@ options:
     help: "Main service container name"
   - name: "flag-x"
     target: X_VALUE
-    type: enum
-    values: [value1, value2, value3]
+    type: select
+    default: "value1"
+    validate:
+      options: ["value1", "value2", "value3"]
     help: "The flag-x defines X behavior. Possible values are value1, value2, and value3"
   - name: "main-port"
     target: MAIN_PORT


### PR DESCRIPTION
The `enum` type has been replaced with `select`, and the `validate` object now includes the new `options` field, which is used to define all possible values of the select. The `default` value should be one of the values in the `validate.options` list.