### PR TITLE
Update Prometheus metrics

### DIFF
--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -1,0 +1,19 @@
+# Glossary
+
+- [Glossary](#glossary)
+  - [AVS (Actively Validated Service)](#avs-actively-validated-service)
+  - [AVS Node](#avs-node)
+  - [Strategy contract](#strategy-contract)
+
+
+## AVS (Actively Validated Service)
+
+Collection of services or middleware software that is built on top of EigenLayer.
+
+## AVS Node
+
+An AVS Node is a node that runs the AVS software. Can be defined as a collection of Docker services declared in a Docker Compose file.
+
+## Strategy contract
+
+A strategy in EigenLayer is a contract that holds staker deposits, meaning it controls one or more asset(s) that can be restaked. At the launch of EigenLayer, the system will feature only simple strategies which may hold a single token. However, the design of EigenLayer's strategies is flexible and open-ended. In the future, strategies could be deployed which implement more intricate logic, including integrations with decentralized finance (DeFi) platforms.

--- a/docs/docs/glossary.md
+++ b/docs/docs/glossary.md
@@ -4,6 +4,7 @@
   - [AVS (Actively Validated Service)](#avs-actively-validated-service)
   - [AVS Node](#avs-node)
   - [Strategy contract](#strategy-contract)
+  - [Eigenlayer Operator](#eigenlayer-operator)
 
 
 ## AVS (Actively Validated Service)
@@ -12,8 +13,12 @@ Collection of services or middleware software that is built on top of EigenLayer
 
 ## AVS Node
 
-An AVS Node is a node that runs the AVS software. Can be defined as a collection of Docker services declared in a Docker Compose file.
+An AVS Node is a node that runs the AVS software as an [Eigenlayer Operator](#eigenlayer-operator). Can be defined as a collection of Docker services declared in a Docker Compose file.
 
 ## Strategy contract
 
 A strategy in EigenLayer is a contract that holds staker deposits, meaning it controls one or more asset(s) that can be restaked. At the launch of EigenLayer, the system will feature only simple strategies which may hold a single token. However, the design of EigenLayer's strategies is flexible and open-ended. In the future, strategies could be deployed which implement more intricate logic, including integrations with decentralized finance (DeFi) platforms.
+
+## Eigenlayer Operator
+
+Eigenlayer Operators act as AVS nodes by opting in to validating AVSs by running their AVS software.

--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -4,9 +4,9 @@ sidebar_position: 0
 
 # Introduction
 
-The [EigenLayer](https://www.eigenlayer.xyz/) ecosystem allows Ethereum validators to restake their ETH and provide services to the network, such as a Data Availability Layer with a particular type of node software called Actively Validated Services (AVS). 
+The [EigenLayer](https://www.eigenlayer.xyz/) ecosystem allows Ethereum validators to restake their ETH and provide services to the network, such as a Data Availability Layer with a particular type of node software called [Actively Validated Services (AVS)](/docs/glossary#avs-actively-validated-service). 
 
-With the increasing number of AVS use cases, there is a need for a convention on how to develop, maintain, create interoperability, and monitor them. Eigenlayer has partnered with Nethermind to create an AVS Node Specification with those goals in mind. We also decided to build an AVS Node Setup Wizard to install and manage AVS Nodes that follow such specification. This documentation describes the AVS Node Specification and the AVS Node Setup Wizard.
+With the increasing number of AVS use cases, there is a need for a convention on how to develop, maintain, create interoperability, and monitor them. Eigenlayer has partnered with Nethermind to create an [AVS Node](/docs/glossary#avs-node) Specification with those goals in mind. We also decided to build an AVS Node Setup Wizard to install and manage AVS Nodes that follow such specification. This documentation describes the AVS Node Specification and the AVS Node Setup Wizard.
 
 The documentation is divided into the following sections:
 

--- a/docs/docs/spec/metrics/metrics-examples.md
+++ b/docs/docs/spec/metrics/metrics-examples.md
@@ -18,7 +18,7 @@ Some metrics and endpoints are very straightforward, but having a reference for 
 ### Economics metrics
 * `eigen_fees_earned_total{token="rETH", unit="wei", strategy="0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2"}`
 * `eigen_slashing_status{avs="eigenDA"}`
-* `eigen_registered_stakes{quorum="beaconChainEth"}`
+* `eigen_registered_stakes{quorum_number=1, quorum_name="beaconChainEth"}`
 
 ### Perfomance metrics
 * `eigen_performance_score`

--- a/docs/docs/spec/metrics/metrics-examples.md
+++ b/docs/docs/spec/metrics/metrics-examples.md
@@ -16,9 +16,9 @@ Some metrics and endpoints are very straightforward, but having a reference for 
 ## Prometheus Metrics
 
 ### Economics metrics
-* `eigen_fees_earned_total{token="ETH"}`
-* `eigen_slashing_incurred_total{token="ETH"}`
-* `eigen_total_balance_total{token="ETH"}`
+* `eigen_fees_earned_total{token="ETH", unit="wei"}`
+* `eigen_slashing_incurred_total{token="ETH", unit="wei"}`
+* `eigen_total_balance_total{token="ETH", unit="wei"}`
 
 ### Perfomance metrics
 * `eigen_performance_score`

--- a/docs/docs/spec/metrics/metrics-examples.md
+++ b/docs/docs/spec/metrics/metrics-examples.md
@@ -24,5 +24,5 @@ Some metrics and endpoints are very straightforward, but having a reference for 
 * `eigen_performance_score`
 
 ### RPC metrics
-* `eigen_rpc_request_duration_seconds{method="eth_getBlockByNumber", client="nethermind", version="1.17.2"}`
-* `eigen_rpc_request_total{method="eth_estimateGas", client="nethermind", version="1.17.2"}` 
+* `eigen_rpc_request_duration_seconds{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}`
+* `eigen_rpc_request_total{method="eth_estimateGas", client_version="nethermind/v1.17.2"}` 

--- a/docs/docs/spec/metrics/metrics-examples.md
+++ b/docs/docs/spec/metrics/metrics-examples.md
@@ -16,9 +16,9 @@ Some metrics and endpoints are very straightforward, but having a reference for 
 ## Prometheus Metrics
 
 ### Economics metrics
-* `eigen_fees_earned_total{token="ETH", unit="wei", strategy="eigenDA"}`
+* `eigen_fees_earned_total{token="rETH", unit="wei", strategy="0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2"}`
 * `eigen_slashing_status{avs="eigenDA"}`
-* `eigen_registered_stakes{token="ETH", unit="wei", strategy="eigenDA"}`
+* `eigen_registered_stakes{quorum="beaconChainEth"}`
 
 ### Perfomance metrics
 * `eigen_performance_score`

--- a/docs/docs/spec/metrics/metrics-examples.md
+++ b/docs/docs/spec/metrics/metrics-examples.md
@@ -16,9 +16,9 @@ Some metrics and endpoints are very straightforward, but having a reference for 
 ## Prometheus Metrics
 
 ### Economics metrics
-* `eigen_fees_earned_total{token="ETH", unit="wei"}`
-* `eigen_slashing_incurred_total{token="ETH", unit="wei"}`
-* `eigen_total_balance_total{token="ETH", unit="wei"}`
+* `eigen_fees_earned_total{token="ETH", unit="wei", strategy="eigenDA"}`
+* `eigen_slashing_status{avs="eigenDA"}`
+* `eigen_registered_stakes{token="ETH", unit="wei", strategy="eigenDA"}`
 
 ### Perfomance metrics
 * `eigen_performance_score`

--- a/docs/docs/spec/metrics/metrics-prom.md
+++ b/docs/docs/spec/metrics/metrics-prom.md
@@ -11,9 +11,9 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 
 | Name | Metric Type | Definition | Labels |
 |---|---|---|---|
-| `eigen_fees_earned_total` | Counter | The amount of fees earned in `<unit>` of underlying `<token>` in the `<strategy>` contract. | `token`, `unit`, `strategy` |
-| `eigen_slashing_status` | Gauge | Slashing status. The value **MUST** be 1 if the operator running `avs` has been slashed. | `avs` |
-| `eigen_registered_stakes` | Gauge | Operator stakes defined by the AVS in `<unit>` of underlying `<token>` in the `<strategy>` contract. | `token`, `unit`, `strategy` |
+| `eigen_fees_earned_total` | Counter | The amount of fees earned in `<unit>` of underlying `<token>` in the `<strategy>` contract. This metric **SHOULD** be omitted while fees are yet to be implemented. | `token`, `unit`, `strategy` |
+| `eigen_slashing_status` | Gauge | Slashing status. The value **MUST** be 1 if the operator running `avs` has been slashed. This metric **SHOULD** not be implemented if there is no slashing in the target network (like in the upcoming testnet launch). | `avs` |
+| `eigen_registered_stakes` | Gauge | Operator stakes representing weighted combination of shares in Eigenlayer strategies. | `quorum` |
 
 :::note
 
@@ -36,9 +36,9 @@ A definition of a strategy contract can be found in the [Glossary](/docs/glossar
 
 ## Notation examples
 
-* `eigen_fees_earned_total{token="ETH", unit="gwei", strategy="eigenDA"}`
+* `eigen_fees_earned_total{token="rETH", unit="gwei", strategy="0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2"}`
 * `eigen_slashing_status{avs="eigenDA}`
-* `eigen_registered_stakes{token="ETH", unit="gwei", strategy="eigenDA"}`
+* `eigen_registered_stakes{quorum="ethLST"}`
 * `eigen_performance_score{}`
 * `eigen_rpc_request_duration_seconds{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}`
 * `eigen_rpc_request_total{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}` 

--- a/docs/docs/spec/metrics/metrics-prom.md
+++ b/docs/docs/spec/metrics/metrics-prom.md
@@ -11,9 +11,9 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 
 | Name | Metric Type | Definition | Labels |
 |---|---|---|---|
-| `eigen_fees_earned_total` | Counter | The amount of fees earned in `<token>` | `token` |
-| `eigen_slashing_incurred_total` | Counter | The amount of slashing incurred in `<token>` | `token` |
-| `eigen_balance_total` | Gauge | AVS Node total balance in `<token>` | `token` |
+| `eigen_fees_earned_total` | Counter | The amount of fees earned in `<unit>` of `<token>` | `token`, `unit` |
+| `eigen_slashing_incurred_total` | Counter | The amount of slashing incurred in `<unit>` of `<token>` | `token`, `unit` |
+| `eigen_balance_total` | Gauge | AVS Node total balance in `<unit>` of `<token>` | `token`, `unit` |
 
 ## Performance metrics
 
@@ -26,13 +26,13 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 | Name | Metric Type | Definition | Labels |
 |---|---|---|---| 
 | `eigen_rpc_request_duration_seconds` | Histogram | Duration of json-rpc `<method>` in seconds from Ethereum Execution client `<client>` | `method`, `client_version` |
-| `eigen_rpc_request_total` | Counter | Total of json-rpc `<method>` requests from Ethereum Execution client `<client>` | `method`,`client_version` |
+| `eigen_rpc_request_total` | Counter | Total of json-rpc `<method>` requests from Ethereum Execution client `<client>` | `method`, `client_version` |
 
 ## Notation examples
 
-* `eigen_fees_earned_total{token="ETH"}`
-* `eigen_slashing_incurred_total{token="ETH"}`
-* `eigen_total_balance_total{token="ETH"}`
+* `eigen_fees_earned_total{token="ETH", unit="gwei"}`
+* `eigen_slashing_incurred_total{token="ETH", unit="gwei"}`
+* `eigen_total_balance_total{token="ETH", unit="gwei"}`
 * `eigen_performance_score{}`
 * `eigen_rpc_request_duration_seconds{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}`
 * `eigen_rpc_request_total{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}` 

--- a/docs/docs/spec/metrics/metrics-prom.md
+++ b/docs/docs/spec/metrics/metrics-prom.md
@@ -11,9 +11,15 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 
 | Name | Metric Type | Definition | Labels |
 |---|---|---|---|
-| `eigen_fees_earned_total` | Counter | The amount of fees earned in `<unit>` of `<token>` | `token`, `unit` |
-| `eigen_slashing_incurred_total` | Counter | The amount of slashing incurred in `<unit>` of `<token>` | `token`, `unit` |
-| `eigen_balance_total` | Gauge | AVS Node total balance in `<unit>` of `<token>` | `token`, `unit` |
+| `eigen_fees_earned_total` | Counter | The amount of fees earned in `<unit>` of underlying `<token>` in the`<strategy>` contract. | `token`, `unit`, `strategy` |
+| `eigen_slashing_status` | Gauge | Slashing status. The value **MUST** be 1 if the operator running `avs` has been slashed. | `avs` |
+| `eigen_registered_stakes` | Gauge | Operator stakes defined by the AVS in `<unit>` of underlying `<token>` in the `<strategy>`contract. | `token`, `unit`, `strategy` |
+
+:::note
+
+A definition of a strategy contract can be found in the [Glossary](/docs/glossary#strategy-contract).
+
+:::
 
 ## Performance metrics
 
@@ -30,9 +36,9 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 
 ## Notation examples
 
-* `eigen_fees_earned_total{token="ETH", unit="gwei"}`
-* `eigen_slashing_incurred_total{token="ETH", unit="gwei"}`
-* `eigen_total_balance_total{token="ETH", unit="gwei"}`
+* `eigen_fees_earned_total{token="ETH", unit="gwei", strategy="eigenDA"}`
+* `eigen_slashing_status{avs="eigenDA}`
+* `eigen_registered_stakes{token="ETH", unit="gwei", strategy="eigenDA"}`
 * `eigen_performance_score{}`
 * `eigen_rpc_request_duration_seconds{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}`
 * `eigen_rpc_request_total{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}` 

--- a/docs/docs/spec/metrics/metrics-prom.md
+++ b/docs/docs/spec/metrics/metrics-prom.md
@@ -13,7 +13,7 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 |---|---|---|---|
 | `eigen_fees_earned_total` | Counter | The amount of fees earned in `<unit>` of underlying `<token>` in the `<strategy>` contract. This metric **SHOULD** be omitted while fees are yet to be implemented. | `token`, `unit`, `strategy` |
 | `eigen_slashing_status` | Gauge | Slashing status. The value **MUST** be 1 if the operator running `avs` has been slashed. This metric **SHOULD** not be implemented if there is no slashing in the target network (like in the upcoming testnet launch). | `avs` |
-| `eigen_registered_stakes` | Gauge | Operator stakes representing weighted combination of shares in Eigenlayer strategies. | `quorum` |
+| `eigen_registered_stakes` | Gauge | Operator stakes in AVS registry contract. Most commonly represents a weighted combination of delegated shares in the `DelegationManager` Eigenlayer contract. | `quorum` |
 
 :::note
 

--- a/docs/docs/spec/metrics/metrics-prom.md
+++ b/docs/docs/spec/metrics/metrics-prom.md
@@ -13,11 +13,17 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 |---|---|---|---|
 | `eigen_fees_earned_total` | Counter | The amount of fees earned in `<unit>` of underlying `<token>` in the `<strategy>` contract. This metric **SHOULD** be omitted while fees are yet to be implemented. | `token`, `unit`, `strategy` |
 | `eigen_slashing_status` | Gauge | Slashing status. The value **MUST** be 1 if the operator running `avs` has been slashed. This metric **SHOULD** not be implemented if there is no slashing in the target network (like in the upcoming testnet launch). | `avs` |
-| `eigen_registered_stakes` | Gauge | Operator stakes in AVS registry contract. Most commonly represents a weighted combination of delegated shares in the `DelegationManager` Eigenlayer contract. | `quorum` |
+| `eigen_registered_stakes` | Gauge | Operator stakes in AVS registry contract. Most commonly represents a weighted combination of delegated shares in the `DelegationManager` Eigenlayer contract. | `quorum_number`, `quorum_name` |
 
 :::note
 
 A definition of a strategy contract can be found in the [Glossary](/docs/glossary#strategy-contract).
+
+:::
+
+:::tip
+
+The `quorum_name` label of the `eigen_registered_stakes` metric is optional and can be omitted.
 
 :::
 
@@ -38,7 +44,7 @@ A definition of a strategy contract can be found in the [Glossary](/docs/glossar
 
 * `eigen_fees_earned_total{token="rETH", unit="gwei", strategy="0x1BeE69b7dFFfA4E2d53C2a2Df135C388AD25dCD2"}`
 * `eigen_slashing_status{avs="eigenDA}`
-* `eigen_registered_stakes{quorum="ethLST"}`
+* `eigen_registered_stakes{quorum_number=0, quorum_name="ethLST"}`
 * `eigen_performance_score{}`
 * `eigen_rpc_request_duration_seconds{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}`
 * `eigen_rpc_request_total{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}` 

--- a/docs/docs/spec/metrics/metrics-prom.md
+++ b/docs/docs/spec/metrics/metrics-prom.md
@@ -11,9 +11,9 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 
 | Name | Metric Type | Definition | Labels |
 |---|---|---|---|
-| `eigen_fees_earned_total` | Counter | The amount of fees earned in `<unit>` of underlying `<token>` in the`<strategy>` contract. | `token`, `unit`, `strategy` |
+| `eigen_fees_earned_total` | Counter | The amount of fees earned in `<unit>` of underlying `<token>` in the `<strategy>` contract. | `token`, `unit`, `strategy` |
 | `eigen_slashing_status` | Gauge | Slashing status. The value **MUST** be 1 if the operator running `avs` has been slashed. | `avs` |
-| `eigen_registered_stakes` | Gauge | Operator stakes defined by the AVS in `<unit>` of underlying `<token>` in the `<strategy>`contract. | `token`, `unit`, `strategy` |
+| `eigen_registered_stakes` | Gauge | Operator stakes defined by the AVS in `<unit>` of underlying `<token>` in the `<strategy>` contract. | `token`, `unit`, `strategy` |
 
 :::note
 

--- a/docs/docs/spec/metrics/metrics-prom.md
+++ b/docs/docs/spec/metrics/metrics-prom.md
@@ -25,8 +25,8 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 
 | Name | Metric Type | Definition | Labels |
 |---|---|---|---| 
-| `eigen_rpc_request_duration_seconds` | Histogram | Duration of json-rpc `<method>` in seconds from Ethereum Execution client `<client>` | `method`, `client`, `version` |
-| `eigen_rpc_request_total` | Counter | Total of json-rpc `<method>` requests from Ethereum Execution client `<client>` | `method`,`client`,`version` |
+| `eigen_rpc_request_duration_seconds` | Histogram | Duration of json-rpc `<method>` in seconds from Ethereum Execution client `<client>` | `method`, `client_version` |
+| `eigen_rpc_request_total` | Counter | Total of json-rpc `<method>` requests from Ethereum Execution client `<client>` | `method`,`client_version` |
 
 ## Notation examples
 
@@ -34,5 +34,5 @@ The table below defines metrics which may be captured by AVS Nodes which expose 
 * `eigen_slashing_incurred_total{token="ETH"}`
 * `eigen_total_balance_total{token="ETH"}`
 * `eigen_performance_score{}`
-* `eigen_rpc_request_duration_seconds{method="eth_getBlockByNumber", client="nethermind", version="1.17.2"}`
-* `eigen_rpc_request_total{method="eth_getBlockByNumber", client="nethermind", version="1.17.2"}` 
+* `eigen_rpc_request_duration_seconds{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}`
+* `eigen_rpc_request_total{method="eth_getBlockByNumber", client_version="nethermind/v1.17.2"}` 

--- a/docs/docs/spec/metrics/metrics-prom.md
+++ b/docs/docs/spec/metrics/metrics-prom.md
@@ -7,12 +7,24 @@ id: metrics-prom-spec
 
 The table below defines metrics which may be captured by AVS Nodes which expose metrics to Prometheus. AVSs may expose additional metrics however these should not use the `eigen_` prefix. 
 
+## Economics metrics
+
 | Name | Metric Type | Definition | Labels |
 |---|---|---|---|
 | `eigen_fees_earned_total` | Counter | The amount of fees earned in `<token>` | `token` |
 | `eigen_slashing_incurred_total` | Counter | The amount of slashing incurred in `<token>` | `token` |
 | `eigen_balance_total` | Gauge | AVS Node total balance in `<token>` | `token` |
+
+## Performance metrics
+
+| Name | Metric Type | Definition | Labels |
+|---|---|---|---|
 | `eigen_performance_score` | Gauge | The performance metric is a score between 0 and 100 and each developer can define their own way of calculating the score. The score is calculated based on the performance of the AVS Node and the performance of the backing  services. |  |
+
+## RPC metrics
+
+| Name | Metric Type | Definition | Labels |
+|---|---|---|---| 
 | `eigen_rpc_request_duration_seconds` | Histogram | Duration of json-rpc `<method>` in seconds from Ethereum Execution client `<client>` | `method`, `client`, `version` |
 | `eigen_rpc_request_total` | Counter | Total of json-rpc `<method>` requests from Ethereum Execution client `<client>` | `method`,`client`,`version` |
 


### PR DESCRIPTION
## Changes:

- [Breakdown Prometheus metrics into economics, performance and rpc metrics](https://github.com/NethermindEth/el-node-spec/commit/4d5181739f70e189db2e795bea81aacdb98f7f9a)
- [Merge client and version labels for RPC metrics](https://github.com/NethermindEth/el-node-spec/commit/d21ff0b4f14593ef80dde60e797d2b3a9a607a1e)
- [Add 'unit' label to economics metrics](https://github.com/NethermindEth/el-node-spec/commit/56ab9f071c073ec5d3d48e8f7faae4b2cae4d22c)
- [Add Glossary page](https://github.com/NethermindEth/el-node-spec/commit/a978a2b85182d68af0f214b7dc9e94a88d4d66ab)
- [Update economics metrics](https://github.com/NethermindEth/el-node-spec/commit/d3d74486066e110febf3915b86725b8c52e61067)
  - Replace eigen_slashing_incurred_total with eigen_slashing_status
  - Replace eigen_balance_total with eigen_registered_stakes
  - Add strategy label